### PR TITLE
Patch OIDC library so that automatically adjusts domain of IdP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,3 +190,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
     git submodule update --init && \
     cd vendors/oauth2-client && \
     composer install
+
+# Prepare patches
+COPY ./apply-patches.sh apply-patches.sh
+COPY ./resources/patch _patches
+RUN chmod +x apply-patches.sh

--- a/apply-patches.sh
+++ b/apply-patches.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+patch_dir="_patches"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+PURPLE='\033[0;35m'
+NC='\033[0m'
+
+while read -r patch_file
+do
+    original_file=$(echo $patch_file | sed "s/\.diff//g")
+    original_file=$(echo $original_file | sed "s/_patches\///g")
+    printf "\n${PURPLE}Patching: ${GREEN}$original_file${NC} ==> "
+    cmdout=$(/usr/bin/env patch --ignore-whitespace --fuzz 3 --dry-run $original_file $patch_file)
+    if [[ "$cmdout" == *"FAILED"* ]]; then
+        printf "${RED}FAILED!${NC}\n"
+    else
+        cmdout=$(/usr/bin/env patch -s $original_file $patch_file)
+        printf "${GREEN}DONE!${NC}\n"
+    fi
+done < <(find $patch_dir -type f -name "*\.diff")

--- a/composer.local.json
+++ b/composer.local.json
@@ -1,6 +1,18 @@
 {
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://gerrit.wikimedia.org/r/mediawiki/extensions/OpenIDConnect"
+        },
+        {
+            "type": "vcs",
+            "url": "https://gerrit.wikimedia.org/r/mediawiki/extensions/PluggableAuth"
+        }
+    ],
     "require": {
-        "rht/merkle-tree": "dev-master"
+        "rht/merkle-tree": "dev-master",
+        "mediawiki/openidconnect": "8.0.*",
+        "mediawiki/pluggable-auth": "7.1.*"
     },
     "extra": {
         "merge-plugin": {

--- a/resources/patch/vendor/jumbojett/openid-connect-php/src/OpenIDConnectClient.php.diff
+++ b/resources/patch/vendor/jumbojett/openid-connect-php/src/OpenIDConnectClient.php.diff
@@ -1,0 +1,14 @@
+--- jumbojett.orig/openid-connect-php/src/OpenIDConnectClient.php       2024-04-09 11:43:43.693588959 +0000
++++ jumbojett/openid-connect-php/src/OpenIDConnectClient.php    2024-04-09 11:43:51.901642424 +0000
+@@ -1416,6 +1416,11 @@
+      * @return mixed
+      */
+     protected function fetchURL($url, $post_body = null, $headers = []) {
++       // Patch - make SIWE accessible inside the container
++       $outSiweURL = $GLOBALS['wgSIWEhost'];
++       $outSiwePort = $GLOBALS['wgSIWEport'];
++       $url = preg_replace( "/(^http:\/\/|https:\/\/)($outSiweURL)(:$outSiwePort.*$)/", '$1siwe-oidc$3', $url );
++       // End patch
+
+         // OK cool - then let's create a new cURL resource handle
+         $ch = curl_init();


### PR DESCRIPTION
- manualy entry in `/etc/hosts` no longer necessary
- OpenIdConnect and Pluggable auth now installed over composer

Furthermore, i added a full patching mechanism, that can be used for other patches as well, just put `diff `files at appropriate path in 'resources/patches`' directory and they will be auto-applied